### PR TITLE
2 bugs fixed and 1 new feature added

### DIFF
--- a/needle/core/device/device.py
+++ b/needle/core/device/device.py
@@ -47,12 +47,13 @@ class Device(object):
     # ==================================================================================================================
     # INIT
     # ==================================================================================================================
-    def __init__(self, ip, port, username, password, tools):
+    def __init__(self, ip, port, username, password, pub_key_auth, tools):
         # Setup params
         self._ip = ip
         self._port = port
         self._username = username
         self._password = password
+        self._pub_key_auth = bool(pub_key_auth)
         self._tools_local = tools
         # Init related objects
         self.app = App(self)
@@ -60,7 +61,6 @@ class Device(object):
         self.local_op = LocalOperations()
         self.remote_op = RemoteOperations(self)
         self.printer = Printer()
-        self.connect()
 
     # ==================================================================================================================
     # UTILS - USB
@@ -89,9 +89,9 @@ class Device(object):
             self.printer.verbose('Setting up SSH connection...')
             self.conn = paramiko.SSHClient()
             self.conn.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            self.conn.connect(self._ip, port=self._port,
-                              username=self._username, password=self._password,
-                              allow_agent=False, look_for_keys=False)
+            self.conn.connect(self._ip, port=self._port, username=self._username, password=self._password,
+                              allow_agent=self._pub_key_auth, look_for_keys=self._pub_key_auth)
+
         except paramiko.AuthenticationException as e:
             raise Exception('Authentication failed when connecting to %s. %s: %s' % (self._ip, type(e).__name__, e.message))
         except paramiko.SSHException as e:

--- a/needle/core/framework/cli.py
+++ b/needle/core/framework/cli.py
@@ -56,6 +56,7 @@ class CLI(Framework):
         self.register_option('verbose', Constants.GLOBAL_VERBOSE, True, 'Enable verbose output')
         self.register_option('app', '', False, 'Bundle ID of the target application (e.g., com.example.app). Leave empty to launch wizard')
         self.register_option('setup_device', Constants.GLOBAL_SETUP_DEVICE, True, 'Set to true to enable auto-configuration of the device (installation of all the tools needed)')
+        self.register_option('pub_key_auth', Constants.GLOBAL_PUB_KEY_AUTH, True, 'Use public key auth. Key must be present in the ssh-agent if a passphrase is used')
 
     def _init_global_vars(self):
         # Setup Printer

--- a/needle/core/framework/framework.py
+++ b/needle/core/framework/framework.py
@@ -621,21 +621,24 @@ class Framework(cmd.Cmd):
         PORT = self._global_options['port']
         USERNAME = self._global_options['username']
         PASSWORD = self._global_options['password']
-        return IP, PORT, USERNAME, PASSWORD
+        PUB_KEY_AUTH = self._global_options['pub_key_auth']
+        return IP, PORT, USERNAME, PASSWORD, PUB_KEY_AUTH
 
     def _spawn_device(self):
         """Instantiate a new Device object, and open a connection."""
-        IP, PORT, USERNAME, PASSWORD = self._parse_device_options()
-        self.device = Framework.device = Device(IP, PORT, USERNAME, PASSWORD, self.TOOLS_LOCAL)
+        IP, PORT, USERNAME, PASSWORD, PUB_KEY_AUTH = self._parse_device_options()
+        self.device = Framework.device = Device(IP, PORT, USERNAME, PASSWORD, PUB_KEY_AUTH, self.TOOLS_LOCAL)
 
     def _connection_new(self):
-        """Try to instaurate a new connection with the device."""
+        """Try to instantiate a new connection with the device."""
         try:
             self._spawn_device()
+            self.device.connect()
             self.printer.notify("Connected to: %s" % self._global_options['ip'])
         except Exception as e:
             self.printer.error("Problem establishing connection: %s - %s " % (type(e).__name__, e.message))
             self.print_exception()
+            self.device.disconnect()
             self.device = Framework.device = None
             return None
         return self.device
@@ -647,9 +650,14 @@ class Framework(cmd.Cmd):
             self.printer.verbose('Connection not present, creating a new instance')
             return self._connection_new()
         else:
-            # Check connection we have is with the current chosen IP
-            if self._global_options['ip'] != self.device._ip:
-                self.printer.verbose('IP changed in global options. Establishing a new connection')
+            # Check connection we have is with the current chosen IP, PORT, USERNAME, PASSWORD, PUB_KEY_AUTH
+            if self._global_options['ip'] != self.device._ip or \
+               self._global_options['port'] != self.device._port or \
+               self._global_options['username'] != self.device._username or \
+               self._global_options['password'] != self.device._password or \
+               self._global_options['pub_key_auth'] != self.device._pub_key_auth:
+
+                self.printer.verbose('Settings changed in global options. Establishing a new connection')
                 self.device = Framework.device = None
                 return self._connection_new()
             else:

--- a/needle/core/utils/constants.py
+++ b/needle/core/utils/constants.py
@@ -22,7 +22,8 @@ class Constants(object):
     GLOBAL_PASSWORD = 'alpine'
     GLOBAL_DEBUG = False
     GLOBAL_VERBOSE = True
-    GLOBAL_SETUP_DEVICE = True
+    GLOBAL_SETUP_DEVICE = False
+    GLOBAL_PUB_KEY_AUTH = True
 
     # LOCAL TOOLS
     PATH_LIBS = os.path.join(sys.path[0], 'libs')


### PR DESCRIPTION
New features:
- Possibility to connect to the iDevice using a public key if it is present in the ssh agent. If not the password will be used

Bugs found and fixed:
- When a user connects to a device, the settings were bound to the needle session. If the user wants to connect using other settings, like another username, password, port, he/she must quit needle and start a new session. Now it's possible to change the settings and connect wihtout having to restart needle.
-The tcp relay connection was being left open when a user tries to connect to a device and for some reason its not possible, lets say the password is wrong and the user use the "exit" command to leave needle's prompt, the tcp relay connection won't be closed (this bug applies to usb connections). Now even if the connection is not successful the tcp relay connection is always terminated before leaving needle.