### PR TITLE
iOS 9.3.3 search pid support inside containers

### DIFF
--- a/needle/core/device/app.py
+++ b/needle/core/device/app.py
@@ -168,6 +168,8 @@ class App(object):
         out = self._device.remote_op.command_blocking(cmd)
         try:
             process_list = filter(lambda x: '/var/mobile' in x, out)
+            if len(process_list) == 0:
+                process_list = filter(lambda x: '/var/containers' in x, out)
             process = process_list[0].strip()
             pid = process.split(' ')[0]
             self._device.printer.verbose('PID found: %s' % pid)


### PR DESCRIPTION
Hello, 
I did update search_pid function to find through /var/containers IF the return result is Zero from /var/mobile


Kernel : Darwin XTest-iPhone 15.6.0 Darwin Kernel Version 15.6.0: Mon Jun 20 20:10:21 PDT 2016; root:xnu-3248.60.9~1/RELEASE_ARM64_S5L8960X iPhone6,2 arm64 N53AP Darwin


