### PR TITLE
Allow using nano to edit hosts file

### DIFF
--- a/needle/core/utils/constants.py
+++ b/needle/core/utils/constants.py
@@ -49,6 +49,7 @@ class Constants(object):
         'MITMDUMP': 'mitmdump',
         'OPENSSL': 'openssl',
         'VIM': 'vim',
+        'NANO': 'nano',
         'OPEN': 'open'
     }
     DISABLE_HOST_VERIFICATION = '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'

--- a/needle/modules/various/hosts.py
+++ b/needle/modules/various/hosts.py
@@ -9,6 +9,7 @@ class Module(BaseModule):
         'description': "Show the content of the device's /etc/hosts file, and offer the chance to edit it",
         'options': (
             ('edit', False, True, 'Modify the /etc/hosts file of the device.'),
+            ('program', 'VIM', True, 'Select the program to use for editing the file. Currently supported: VIM, NANO'),
         ),
     }
 
@@ -36,11 +37,20 @@ class Module(BaseModule):
 
         # Modify the file
         if self.options['edit']:
+
+            # Check that the user entered a recognised editor in the PROGRAM option by seeing if it
+            # exists in the TOOLS_LOCAL directory
+            if self.options['program'] in self.TOOLS_LOCAL:
+                editor = self.TOOLS_LOCAL[self.options['program']]
+            else:
+                self.printer.error('Editing program "{}" specified is not supported.'.format(self.options['program']))
+                return
+
             # Pull the file
             self.device.pull(self.path_remote, self.path_local)
 
-            # Modify it
-            cmd = '{vim} {fname}'.format(vim=self.TOOLS_LOCAL['VIM'],
+            # Modify it in the selected editor
+            cmd = '{editor} {fname}'.format(editor=editor,
                                          fname=self.path_local)
             self.local_op.command_interactive(cmd)
 


### PR DESCRIPTION
### Added

Changes proposed in this pull request: 
- Allow the use of nano when editing a hosts file using `needle/modules/various/hosts.py` because changing the module was quicker than trying to remember the edit and then quit commands in vi ;)
