### PR TITLE
New module: View TLS certificate details

### DIFF
--- a/needle/core/utils/constants.py
+++ b/needle/core/utils/constants.py
@@ -94,6 +94,7 @@ class Constants(object):
             # PROGRAMS
             'CLASS-DUMP': {'COMMAND': 'class-dump', 'PACKAGES': ['pcre', 'net.limneos.classdump-dyld', 'class-dump'], 'REPO': '', 'LOCAL': None},
             'CLUTCH': {'COMMAND': 'Clutch2', 'PACKAGES': ['com.iphonecake.clutch2'], 'REPO': 'http://cydia.iphonecake.com/', 'LOCAL': None},
+            'CURL': {'COMMAND': 'curl', 'PACKAGES': None, 'REPO': None, 'LOCAL': None},
             'CYCRIPT': {'COMMAND': 'cycript', 'PACKAGES': ['cycript'], 'REPO': None, 'LOCAL': None},
             #'DEBUGSERVER': {'COMMAND': '/usr/bin/debugserver', 'PACKAGES': None, 'REPO': None, 'LOCAL': os.path.join(PATH_DEVICETOOLS, 'debugserver_81')},
             'FILEDP': {'COMMAND': 'FileDP', 'PACKAGES': None, 'REPO': None, 'LOCAL': os.path.join(PATH_DEVICETOOLS, 'FileDP')},

--- a/needle/modules/comms/certs/view_cert.py
+++ b/needle/modules/comms/certs/view_cert.py
@@ -10,7 +10,8 @@ class Module(BaseModule):
             ('url', 'google.com', True, 'Site URL to check (https:// will be added to the front'),
             ('proxy', None, False, 'HTTP proxy to use when checking in the form host:port')
         ),
-        'comments': ['This script doesn\'t currently verify the validity of the certificate.']
+        'comments': ['This script doesn\'t currently verify the validity of the certificate.',
+                     'https://github.com/mwrlabs/needle/pull/62#issuecomment-254037231']
     }
 
     # ==================================================================================================================
@@ -29,15 +30,23 @@ class Module(BaseModule):
     def module_run(self):
 
         # Start building the cURL command
-        cmd = '{curl} --insecure -v https://{url} '.format(curl=self.device.DEVICE_TOOLS['CURL'], url=self.options['url'])
+        cmd = '{curl} --insecure https://{url} '.format(curl=self.device.DEVICE_TOOLS['CURL'], url=self.options['url'])
 
         # Add a proxy if relevant
         if self.options['proxy'] is not None:
             cmd += ' -x {} '.format(self.options['proxy'])
 
+        # Run the command for the first time to check for errors
+        # This command will automatically report if the URL is incorrect or if there is an issue with the proxy
+        self.device.remote_op.command_blocking('{} --fail --silent --show-error'.format(cmd))
+
+        self.printer.info('Getting the certificate...')
+
         # Use awk to display only the relevant lines from the output
-        cmd += " 2>&1 | awk 'BEGIN { cert=0 } /^\* Server certificate:/ { cert=1 } /^\*/ { if (cert) print }'"
+        cmd += "-v 2>&1 | awk 'BEGIN { cert=0 } /^\* Server certificate:/ { cert=1 } /^\*/ { if (cert) print }'"
 
         # Run the command and print to screen
+        # This command will automatically report if the URL is incorrect or if there is an issue with the proxy
         out = self.device.remote_op.command_blocking(cmd)
+
         self.print_cmd_output(out)

--- a/needle/modules/comms/certs/view_cert.py
+++ b/needle/modules/comms/certs/view_cert.py
@@ -29,7 +29,7 @@ class Module(BaseModule):
     def module_run(self):
 
         # Start building the cURL command
-        cmd = 'curl --insecure -v https://{} '.format(self.options['url'])
+        cmd = '{curl} --insecure -v https://{url} '.format(curl=self.device.DEVICE_TOOLS['CURL'], url=self.options['url'])
 
         # Add a proxy if relevant
         if self.options['proxy'] is not None:

--- a/needle/modules/comms/certs/view_cert.py
+++ b/needle/modules/comms/certs/view_cert.py
@@ -1,0 +1,43 @@
+from core.framework.module import BaseModule
+
+
+class Module(BaseModule):
+    meta = {
+        'name': 'View Server Certificate',
+        'author': '@tghosth (@JoshCGrossman)',
+        'description': 'View details of TLS certificate presented by a specified site.',
+        'options': (
+            ('url', 'google.com', True, 'Site URL to check (https:// will be added to the front'),
+            ('proxy', None, False, 'HTTP proxy to use when checking in the form host:port')
+        ),
+        'comments': ['This script doesn\'t currently verify the validity of the certificate.']
+    }
+
+    # ==================================================================================================================
+    # UTILS
+    # ==================================================================================================================
+    def __init__(self, params):
+        BaseModule.__init__(self, params)
+
+
+    def module_pre(self):
+        return BaseModule.module_pre(self, bypass_app=True)
+
+    # ==================================================================================================================
+    # RUN
+    # ==================================================================================================================
+    def module_run(self):
+
+        # Start building the cURL command
+        cmd = 'curl --insecure -v https://{} '.format(self.options['url'])
+
+        # Add a proxy if relevant
+        if self.options['proxy'] is not None:
+            cmd += ' -x {} '.format(self.options['proxy'])
+
+        # Use awk to display only the relevant lines from the output
+        cmd += " 2>&1 | awk 'BEGIN { cert=0 } /^\* Server certificate:/ { cert=1 } /^\*/ { if (cert) print }'"
+
+        # Run the command and print to screen
+        out = self.device.remote_op.command_blocking(cmd)
+        self.print_cmd_output(out)


### PR DESCRIPTION
### Added

Changes proposed in this pull request: 
- Add a module (`view_cert.py`) which shows some very basic TLS certificate details for a specified URL with the option to set a proxy. Whilst this is easy under Android, there is no built in way of doing it via the iOS UI and the only app I could find which would do it ignored the device proxy settings and had no option for configuring the proxy. See also my additional comment below.
