### PR TITLE
JSON serialize datetime in plist

### DIFF
--- a/needle/core/utils/utils.py
+++ b/needle/core/utils/utils.py
@@ -5,7 +5,7 @@ import json
 import biplist
 import plistlib
 from pprint import pprint
-
+from datetime import datetime
 
 # ======================================================================================================================
 # GENERAL UTILS
@@ -95,8 +95,22 @@ class Utils(object):
     @staticmethod
     def dict_write_to_file(text, fp):
         """Print a dictionary to file."""
+
+        def json_serial(obj):
+            """
+            JSON serializer for objects not serializable by default json code
+            Currently only handles datetime objects
+            based on: http://stackoverflow.com/a/22238613/7011779
+            """
+
+            if isinstance(obj, datetime):
+                serial = obj.isoformat()
+                return serial
+            raise TypeError("Type not serializable")
+
+
         try:
-            json.dump(text, fp, indent=4)
+            json.dump(text, fp, indent=4, default=json_serial)
         except TypeError as e:
             raise Exception(e)
 


### PR DESCRIPTION
### Bug fix proposed in this pull request:

I have a plist file which when parsed by bplist contained a datetime object. This was causing an error when serializing to JSON:
```
------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/hgfs/Work/needle/needle/core/framework/module.py", line 115, in do_run
    self.module_run()
  File "/mnt/hgfs/Work/needle/needle/modules/storage/data/files_plist.py", line 84, in module_run
    self.save_file(remote_name, local_name, self.options['silent'])
  File "/mnt/hgfs/Work/needle/needle/modules/storage/data/files_plist.py", line 41, in save_file
    self.print_cmd_output(pl, outfile, silent)
  File "/mnt/hgfs/Work/needle/needle/core/framework/module.py", line 191, in print_cmd_output
    print_file(txt)
  File "/mnt/hgfs/Work/needle/needle/core/framework/module.py", line 172, in print_file
    Utils.dict_write_to_file(content, fp)
  File "/mnt/hgfs/Work/needle/needle/core/utils/utils.py", line 115, in dict_write_to_file
    raise Exception(e)
Exception: datetime.datetime(2017, 1, 2, 15, 20, 0, 592541) is not JSON serializable
------------------------------------------------------------
[!] Exception: datetime.datetime(2017, 1, 2, 15, 20, 0, 592541) is not JSON serializable.

```

I have fixed this issue by providing a custom method for deserializing datetime data based on a [following stackoverflow response](http://stackoverflow.com/a/22238613/7011779). 