### PR TITLE
Fix Paramiko hanging issue

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,7 +116,8 @@ Tell us what happens instead.
 
 Unsure where to begin contributing? You can start by looking through:
 
-* :mag_right: [open issues](https://github.com/mwrlabs/needle/issues)
+* :mag_right: **[Open Issues](https://github.com/mwrlabs/needle/issues)**
+* :memo: **New Features**: contact [Marco](https://github.com/marco-lancini) ([@lancinimarco](https://twitter.com/lancinimarco))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 #### Added
+#### Fixed
+#### Removed
+
+
+
+## [0.1.1] - 2016-11-25
+#### Added
 - **[CORE]** Support for plist files into print_cmd_output
 - **[CORE]** `move` function for Remote operations
 - **[CORE]** Automatically install Theos
@@ -33,8 +40,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **[MODULE]** Error saving files in `storage/data/files_*` modules _[from @tghosth]_
 - **[MODULE]** Run proxy regular even without selecting a target app
 - **[MODULE]** File monitoring: automatically detect folder to monitor (regression)
-
-#### Removed
 
 
 

--- a/needle/VERSION
+++ b/needle/VERSION
@@ -1,4 +1,4 @@
-__version__ = '0.0.4'
+__version__ = '0.1.1'
 
 # ex. x.y.z
 # x - Incremented for changes requiring migration. (major revision)

--- a/needle/core/device/device.py
+++ b/needle/core/device/device.py
@@ -109,6 +109,15 @@ class Device(object):
         """Execute a shell command on the device, then parse/print output."""
         # Paramiko Exec Command
         stdin, stdout, stderr = self.conn.exec_command(cmd)
+        # Prevent open channels from hanging / waiting for returned output
+        import time
+        timeout = 30
+        endtime = time.time() + timeout
+        while not stdout.channel.eof_received:
+            time.sleep(1)
+            if time.time() > endtime:
+                stdout.channel.close()
+                break
         # Parse STDOUT/ERR
         # TODO: FIX
         #out = stdout.read().decode('iso-8859-1').split('\n')


### PR DESCRIPTION
Refer to Issue #67

### Added

Changes proposed in this pull request: 

111a112,120
>         # Prevent open channels from hanging / waiting for returned output
>         import time
>         timeout = 30
>         endtime = time.time() + timeout
>         while not stdout.channel.eof_received:
>             time.sleep(1)
>             if time.time() > endtime:
>                 stdout.channel.close()
>                 break

### Fixed

Bug fixes proposed in this pull request:

A bug exists in Paramiko (#67) that forces all open channels of a connection to remain open and hang indefinitely until SSH command output is returned/received. This code forces the channels to close after a specified period of time and process the results/output.