### PR TITLE
Update constants.py

### DIFF
--- a/needle/core/utils/constants.py
+++ b/needle/core/utils/constants.py
@@ -134,6 +134,7 @@ class Constants(object):
             # TOOLS
             'CYCRIPT': {'COMMAND': 'cycript', 'PACKAGES': ['cycript'], 'REPO': None, 'LOCAL': None, 'SETUP': None},
             'FRIDA': {'COMMAND': 'frida', 'PACKAGES': ['re.frida.server'], 'REPO': 'https://build.frida.re/', 'LOCAL': None, 'SETUP': None},
+            'IPAINSTALLER': {'COMMAND': 'ipainstaller', 'PACKAGES': ['com.autopear.installipa'], 'REPO': None, 'LOCAL': None, 'SETUP': None},
             'GDB': {'COMMAND': 'gdb', 'PACKAGES': ['gdb'], 'REPO': 'http://cydia.radare.org/', 'LOCAL': None, 'SETUP': None},
             'THEOS': {'COMMAND': 'theos', 'PACKAGES': None, 'REPO': None, 'LOCAL': None, 'SETUP': [
                 "ln -s /usr/local/bin/perl /usr/bin/perl",


### PR DESCRIPTION
IPAINSTALLER is missing in DEVICE_TOOLS resulting in key errors when running modules such as strings.

### Added

Changes proposed in this pull request: 
Add IPAINSTALLER in DEVICE_SETUP similar to previous needle versions
- ...
- ...
- ...


### Fixed

Bug fixes proposed in this pull request:
Fix crash when running strings module
- ...
- ...
- ...
