### PR TITLE
decoding binary_directory

### DIFF
--- a/needle/core/device/app.py
+++ b/needle/core/device/app.py
@@ -1,4 +1,5 @@
 import os
+import urllib2
 from ..utils.constants import Constants
 from ..utils.utils import Utils
 
@@ -74,7 +75,7 @@ class App(object):
             'bundle_id': bundle_id,
             'data_directory': data_directory,
             'bundle_directory': bundle_directory,
-            'binary_directory': binary_directory,
+            'binary_directory': urllib2.unquote(binary_directory),
             'app_version': app_version,
             'sdk_version': sdk_version,
             'entitlements': entitlements,


### PR DESCRIPTION
The binary_directory is determined by bundleURL --- meaning special characters such as spaces are URL encoded. This effectively causes needle to become unusable since any functionality depending on the binary_directory val will break due to the non-existent path.