### PR TITLE
Make "all" uppercase in dependency_installer

### DIFF
--- a/needle/modules/device/dependency_installer.py
+++ b/needle/modules/device/dependency_installer.py
@@ -173,8 +173,8 @@ class Module(BaseModule):
             to_install = [k.upper() for k, v in self.options.iteritems()]
         else:
             to_install = [k.upper() for k, v in self.options.iteritems() if v]
-        if 'all' in to_install:
-            to_install.remove('all')
+        if 'ALL' in to_install:
+            to_install.remove('ALL')
         self.printer.info('The following tools are going to be installed: {}'.format(to_install))
 
         # Configure tools


### PR DESCRIPTION
Looks like searching the to_install collection is case sensitive. This was causing an error when I tried to run the module.

### Added

Changes proposed in this pull request: 

- ...
- ...
- ...


### Fixed

Bug fixes proposed in this pull request:

- ...
- ...
- ...
