### PR TITLE
Fix keychain extraction of data not encodable in UTF8

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the [Installation Guide](https://github.com/mwrlabs/needle/wiki/Installation
 
 #### Supported Platforms
 
-* _Workstation_: Needle has been successfully tested on both Kali and OSX
+* _Workstation_: Needle has been successfully tested on both Kali and macOS
 * _Device_: iOS 8, 9, and 10 are currently supported 
 
 
@@ -35,5 +35,7 @@ Needle is released under a 3-clause BSD License. See the `LICENSE` file for full
 
 
 # Contact
+
+For news and updates, follow [@mwrneedle](https://twitter.com/mwrneedle) on Twitter and the _[MWR Mobile Tools](http://mobiletools.mwrinfosecurity.com/needle/blog)_ blog.
 
 Feel free to submit issues or ping us on Twitter - [@mwrneedle](https://twitter.com/mwrneedle), [@lancinimarco](https://twitter.com/lancinimarco)

--- a/needle/modules/storage/data/keychain_dump_frida.py
+++ b/needle/modules/storage/data/keychain_dump_frida.py
@@ -14,6 +14,14 @@ class Module(FridaScript):
     JS = '''\
 if (ObjC.available) {
 
+    function bytesToHex(bytes) {
+      for (var hex = [], i = 0; i < bytes.length; i++) {
+        hex.push((bytes[i] >>> 4).toString(16));
+        hex.push((bytes[i] & 0xF).toString(16));
+      }
+      return hex.join("");
+    }
+
     function StringFromNSStringUTF8(nsstring){
       var bytearray = nsstring.dataUsingEncoding_(4);
       return Memory.readUtf8String(bytearray.bytes(),bytearray.length());
@@ -116,15 +124,16 @@ if (ObjC.available) {
         for (var i = 0; i < result.count(); i++){
             var entry = result.objectAtIndex_(i);
             send(JSON.stringify({
-                Data: ObjC.classes.NSString.stringWithUTF8String_(entry.objectForKey_("v_Data").bytes()).valueOf(),
-                EntitlementGroup: entry.objectForKey_("agrp").valueOf(),
-                Protection: constants[entry.objectForKey_("pdmn")].valueOf(),
-                AccessControls: decodeACL(entry),
-                CreationTime: entry.objectForKey_("cdat").valueOf(),
-                Account: entry.objectForKey_("acct").valueOf(),
-                Service: entry.objectForKey_("svce").valueOf(),
-                ModifiedTime: entry.objectForKey_("mdat").valueOf(),
-                kSecClass: constants[secItemClasses[secItemClassIter]]
+              Data: bytesToHex(Memory.readByteArray(entry.objectForKey_("v_Data").bytes(),entry.objectForKey_("v_Data").length())) + 
+                    ( ObjC.classes.NSString.stringWithUTF8String_(entry.objectForKey_("v_Data").bytes()) ? " (UTF8 String: '" + ObjC.classes.NSString.stringWithUTF8String_(entry.objectForKey_("v_Data").bytes()).valueOf() + "')": "" ),
+              EntitlementGroup: entry.objectForKey_("agrp").valueOf(),
+              Protection: constants[entry.objectForKey_("pdmn")].valueOf(),
+              AccessControls: decodeACL(entry),
+              CreationTime: entry.objectForKey_("cdat").valueOf(),
+              Account: ( entry.objectForKey_("acct") ? entry.objectForKey_("acct").valueOf() : "null"),
+              Service: ( entry.objectForKey_("svce") ? entry.objectForKey_("svce").valueOf() : "null"),
+              ModifiedTime: entry.objectForKey_("mdat").valueOf(),
+              kSecClass: constants[secItemClasses[secItemClassIter]]
             }));
           }
         }


### PR DESCRIPTION
### Fixed

Bug fixes proposed in this pull request related to Frida Keychain Dump:

- Data extraction fails when data is not encodable in UTF8 (for example extracting keys and certificates from keychain)
- Data extraction fails when account and service are null
- Now data field is printed in HEX and when possible also in UTF8
