### PR TITLE
Update Frida based SSL pinning bypass with iOS10 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Needle](https://labs.mwrinfosecurity.com/assets/needle-logo-blue.jpg)
 
 [![Black Hat Arsenal](https://www.toolswatch.org/badges/arsenal/2016.svg)](https://www.blackhat.com/us-16/arsenal.html#needle)
+[![Black Hat Arsenal](https://rawgit.com/toolswatch/badges/master/arsenal/2017.svg)](https://www.blackhat.com/us-17/arsenal.html#needle)
 
 _Needle_ is an open source, modular framework to streamline the process of conducting security assessments of iOS apps.
 

--- a/needle/modules/comms/proxy/pinning_bypass_frida.py
+++ b/needle/modules/comms/proxy/pinning_bypass_frida.py
@@ -62,17 +62,6 @@ if (ObjC.available) {
         return SSLSetSessionOption(context, option, value);
     }, 'int', ['pointer', 'int', 'bool']));
 
-    // iOS 10
-    var tls_helper_create_peer_trust = new NativeFunction(
-        Module.findExportByName(null, "tls_helper_create_peer_trust"),
-        'int',
-        ['pointer', 'bool', 'pointer']
-    );
-
-    Interceptor.replace(tls_helper_create_peer_trust, new NativeCallback(function(hdsk, server, trustRef) {
-        return noErr;
-    }, 'int', ['pointer', 'bool', 'pointer']));
-
 
     //
     // OLD WAY

--- a/needle/modules/comms/proxy/pinning_bypass_frida.py
+++ b/needle/modules/comms/proxy/pinning_bypass_frida.py
@@ -87,6 +87,20 @@ if (ObjC.available) {
         return ret;
     }, 'int', ['pointer', 'pointer']));
 
+    // tls_helper_create_peer_trust for iOS 10
+    // Ref: https://github.com/nabla-c0d3/ssl-kill-switch2/blob/e9a30a3e749fd0b490cba4c63461116da2c3e586/SSLKillSwitch/SSLKillSwitch.m#L113-L122
+    // Ref: https://nabla-c0d3.github.io/blog/2017/02/05/ios10-ssl-kill-switch/
+    var tls_helper_create_peer_trust = new NativeFunction(
+        Module.findExportByName('libcoretls_cfhelpers.dylib', 'tls_helper_create_peer_trust'),
+        'int', ['void', 'bool', 'pointer']
+    );
+
+    Interceptor.replace(tls_helper_create_peer_trust, new NativeCallback(function (hdsk, server, SecTrustRef) {
+
+        send("Replacing tls_helper_create_peer_trust (iOS 10 support)");
+        return 0 // errSecSuccess;
+    }, 'int', ['void', 'bool', 'pointer']));
+
     //
     // COMMON FRAMEWORKS
     //

--- a/needle/modules/dynamic/detection/script_jailbreak-detection-bypass.py
+++ b/needle/modules/dynamic/detection/script_jailbreak-detection-bypass.py
@@ -62,22 +62,6 @@ var libs = [
     "CYObjectiveC",
     "frida_agent_main"];
 
-Interceptor.attach(ObjC.classes.NSFileManager["- fileExistsAtPath:"].implementation, {
-    onEnter: function (args) {
-        this.path_to_hide = false;
-        this.path = ObjC.Object(args[2]).toString();
-        if (paths.indexOf(this.path) >= 0) {
-            this.path_to_hide = true;
-            send("Hooking fileExistsAtPath to return false");
-        }
-    },
-    onLeave: function (retval) {
-        if (this.path_to_hide) {
-            retval.replace(0x0);
-        }
-    }
-});
-
 var resolver = new ApiResolver('objc');
 resolver.enumerateMatches('*[* is*ailbroken]', {
     onMatch: function (match) {


### PR DESCRIPTION
This PR is a 'frida-ised' version of the work described in the "Fixing SSL Kill Switch on iOS 10" section [here](https://nabla-c0d3.github.io/blog/2017/02/05/ios10-ssl-kill-switch/) and commited [here](https://github.com/nabla-c0d3/ssl-kill-switch2/blob/e9a30a3e749fd0b490cba4c63461116da2c3e586/SSLKillSwitch/SSLKillSwitch.m#L113-L122).

### Added

Changes proposed in this pull request: 

- Update the existing Frida based SSL pinning bypass implementation to include a hook for `tls_helper_create_peer_trust `.

🎉 