### PR TITLE
Update app.py

### DIFF
--- a/needle/core/device/app.py
+++ b/needle/core/device/app.py
@@ -72,7 +72,7 @@ class App(object):
             'bundle_id': bundle_id,
             'data_directory': data_directory,
             'bundle_directory': bundle_directory,
-            'binary_directory': binary_directory,
+            'binary_directory': binary_directory.strip(''''"'''),
             'app_version': app_version,
             'sdk_version': sdk_version,
             'entitlements': entitlements,

--- a/needle/core/framework/module.py
+++ b/needle/core/framework/module.py
@@ -307,7 +307,8 @@ class FridaScript(FridaModule):
             # Launching the app
             self.printer.info("Launching the app...")
             self.device.app.open(self.APP_METADATA['bundle_id'])
-            pid = int(self.device.app.search_pid(self.APP_METADATA['binary_name']))
+            binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
+            pid = int(self.device.app.search_pid(binaryPath))
             # Attaching to the process
             self.printer.info("Attaching to process: %s" % pid)
             self.session = device.attach(pid)

--- a/needle/modules/binary/reversing/class_dump_frida_enum-all-methods.py
+++ b/needle/modules/binary/reversing/class_dump_frida_enum-all-methods.py
@@ -16,7 +16,7 @@ if(ObjC.available) {
     for(var className in ObjC.classes) {
         if(ObjC.classes.hasOwnProperty(className)) {
             send("Class: " + className);
-            var methods = eval('ObjC.classes.'+className+'.$methods');
+            var methods = eval('ObjC.classes[className].$ownMethods');
             for (var i = 0; i < methods.length; i++) {
                 send(JSON.stringify({class:className.toString(), method:methods[i].toString()}));
             }

--- a/needle/modules/binary/reversing/class_dump_frida_find-class-enum-methods.py
+++ b/needle/modules/binary/reversing/class_dump_frida_find-class-enum-methods.py
@@ -14,7 +14,8 @@ class Module(FridaScript):
 
     JS = '''\
 if(ObjC.available) {
-    var methods = ObjC.classes.%s.$methods;
+    var className = '%s';
+    var methods = eval('ObjC.classes[className].$ownMethods');
     for (var i = 0; i < methods.length; i++) {
         send(JSON.stringify({class:'%s', method:methods[i].toString()}));
     }

--- a/needle/modules/hooking/cycript/cycript_shell.py
+++ b/needle/modules/hooking/cycript/cycript_shell.py
@@ -18,7 +18,8 @@ class Module(BaseModule):
         self.printer.info("Launching the app...")
         self.device.app.open(self.APP_METADATA['bundle_id'])
         # Search for PID
-        pid = self.device.app.search_pid(self.APP_METADATA['binary_name'])
+        binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
+        pid = self.device.app.search_pid(binaryPath)
         # Launch Cycript shell
         self.printer.info("Spawning a Cycript shell...")
         cmd = "{bin} -p {app}".format(bin=self.device.DEVICE_TOOLS['CYCRIPT'], app=pid)

--- a/needle/modules/hooking/cycript/cycript_touchid.py
+++ b/needle/modules/hooking/cycript/cycript_touchid.py
@@ -18,7 +18,8 @@ class Module(BaseModule):
         self.printer.info("Launching the app...")
         self.device.app.open(self.APP_METADATA['bundle_id'])
         # Search for PID
-        pid = self.device.app.search_pid(self.APP_METADATA['binary_name'])
+        binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
+        pid = self.device.app.search_pid(binaryPath)
 
         # Prepare hook
         fname = "hook.cy"

--- a/needle/modules/hooking/frida/script_anti-hooking-check.py
+++ b/needle/modules/hooking/frida/script_anti-hooking-check.py
@@ -41,13 +41,13 @@ if(ObjC.available) {
     # ==================================================================================================================
     # RUN
     # ==================================================================================================================
-    def module_pre(self):
+    '''def module_pre(self):
         """Automatically detect if the app prevents hooking."""
         try:
             FridaScript.module_pre()
         except Exception as e:
             self.msg = e
-            self.module_run()
+            self.module_run()'''
 
     def module_run(self):
         # If error has been detected, log issue and exit

--- a/needle/modules/hooking/frida/script_hook-method-of-class.py
+++ b/needle/modules/hooking/frida/script_hook-method-of-class.py
@@ -18,25 +18,25 @@ if(ObjC.available) {
     var className = "%s";
     var methodName = "%s";
 
-    var hook = eval('ObjC.classes.' + className + '["' + methodName + '"]');
+    var hook = eval('ObjC.classes[className][methodName]');
     Interceptor.attach(hook.implementation, {
           onEnter: function(args) {
                 // args[0] is self
                 // args[1] is selector (SEL "sendMessageWithText:")
                 // args[2] holds the first function argument, an NSString
-                console.log("[*] Detected call to: " + className + " -> " + funcName);
+                console.log("[*] Detected call to: " + className + " -> " + methodName);
                 //For viewing and manipulating arguments
                 //console.log("\t[-] Value1: "+ObjC.Object(args[2]));
                 //console.log("\t[-] Value2: "+(ObjC.Object(args[2])).toString());
                 //console.log(args[2]);
           }
-          onLeave: function(retval) {
+          /**onLeave: function(retval) {
                 console.log("[*] Class Name: " + className);
                 console.log("[*] Method Name: " + methodName);
                 console.log("\t[-] Type of return value: " + typeof retval);
                 //console.log(retval.toString());
                 console.log("\t[-] Return Value: " + retval);
-          }
+          }**/
     });
 } else {
     console.log("Objective-C Runtime is not available!");


### PR DESCRIPTION
fixed an issue where if the "bundle executable" name is more than one word, needle inserts random single quotes and double quotes between ".app" and "/Info.plist"

example, before this fix, when i try to pull the meta data for all app called "my app", needle uses the following command locally:

sshpass -p "alpine" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 2222 root@127.0.0.1:"'/private/var/containers/Bundle/Application/<UUID>/my app.app'"'"'"'"'"'"'"'"'/Info.plist'" /root/.needle/tmp/plist

after this fix, the local command looks like the following:

sshpass -p "alpine" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 2222 root@127.0.0.1:"'/private/var/containers/Bundle/Application/<UUID>/my app.app/Info.plist'" /root/.needle/tmp/plist
