### PR TITLE
Fix Handling of periods in class names - class_dump_frida_find-class-enum-methods.py

### DIFF
--- a/needle/modules/binary/reversing/class_dump_frida_find-class-enum-methods.py
+++ b/needle/modules/binary/reversing/class_dump_frida_find-class-enum-methods.py
@@ -14,7 +14,8 @@ class Module(FridaScript):
 
     JS = '''\
 if(ObjC.available) {
-    var methods = ObjC.classes.%s.$methods;
+    var className = '%s';
+    var methods = eval('ObjC.classes[className].$ownMethods');
     for (var i = 0; i < methods.length; i++) {
         send(JSON.stringify({class:'%s', method:methods[i].toString()}));
     }


### PR DESCRIPTION
fixes same issue outlined in https://github.com/mwrlabs/needle/pull/227