### PR TITLE
Fix how the module "cycript_touchid.py" finds running processes via "ps ax | grep"

### DIFF
--- a/needle/modules/hooking/cycript/cycript_touchid.py
+++ b/needle/modules/hooking/cycript/cycript_touchid.py
@@ -18,7 +18,9 @@ class Module(BaseModule):
         self.printer.info("Launching the app...")
         self.device.app.open(self.APP_METADATA['bundle_id'])
         # Search for PID
-        pid = self.device.app.search_pid(self.APP_METADATA['binary_name'])
+        binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
+        binaryPath = binaryPath.replace("'","")
+        pid = self.device.app.search_pid(binaryPath)
 
         # Prepare hook
         fname = "hook.cy"


### PR DESCRIPTION
the module "hooking/cycript/cycript_touchid" does the following commands on the iphone to launch a cycript shell:

```
iphone root# ps ax | grep -i '<app name'
iphone root# cycript -p
```

now i found an interesting issue when using this module with the app "LINE". the following is the output from "ps ax | grep -i 'LINE':

```
983 ?? Ss 0:00.11 /usr/libexec/online-auth-agent
1563 ?? Ss 0:00.72 /var/containers/Bundle/Application/95376AF3-237B-49B2-98EB-DEDF50984CB7/LINE.app/LINE
1583 s000 R+ 0:00.00 grep -i LINE
```

notice how the first process (983) is for a different process than the app. what i found is that the needle module will attach the cycript program to the first process and not the actual LINE app:

```
[D] [REMOTE CMD] Remote Interactive TTY Command: cycript -p 983
```

this patch addresses the above issue by making the "ps" command look for the binary directory instead of the app name.

log below showing the proposed changes working on an iOS 10 device

```
[needle] > set debug true
DEBUG => true
[needle] > set app com.apple.camera
APP => com.apple.camera
[needle] > use hooking/cycript/cycript_shell
[needle][cycript_shell] > run
[D] Setup local output folder: /root/.needle/output
[D] Setting up issues database...
[D] [DB] QUERY: CREATE TABLE IF NOT EXISTS issues (app TEXT, module TEXT, name TEXT, content TEXT, confidence TEXT, outfile TEXT)
[*] Checking connection with device...
[V] Connection not present, creating a new instance
[D] Setting up USB port forwarding on port 2222
[D] [LOCAL CMD] Local Subprocess Command: /root/Programs/needle/needle/libs/usbmuxd/tcprelay.py -t 22:2222
[D] [AGENT] Setting up port forwarding on port 4444
[V] [AGENT] Connecting to agent (127.0.0.1:4444)...
[+] [AGENT] Successfully connected to agent (127.0.0.1:4444)...
[D] [AGENT] Executing command: os_version
[V] [SSH] Connecting (127.0.0.1:2222)...
[+] [SSH] Connected (127.0.0.1:2222)
[D] Creating temp folder: /var/root/needle/
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/ ]; then echo "yes"; else echo "no" ; fi
[D] [AGENT] Executing command: os_version
[+] Target app: com.apple.camera
[*] Retrieving app's metadata...
[D] [AGENT] Executing command: list_apps
[D] Copying the plist to temp: /Applications/Camera.app/Info.plist -> /root/.needle/tmp/plist
[*] Pulling: /Applications/Camera.app/Info.plist -> /root/.needle/tmp/plist
[D] Downloading: "/Applications/Camera.app/Info.plist" -> /root/.needle/tmp/plist
[D] [LOCAL CMD] Local Command: sshpass -p "<password>" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 2222 root@127.0.0.1:"/Applications/Camera.app/Info.plist" /root/.needle/tmp/plist
[D] [REMOTE CMD] Remote Command: lipo -info /Applications/Camera.app/Camera
[D] [REMOTE CMD] Remote Command: if [ -d /Applications/Camera.app/PlugIns ]; then echo "yes"; else echo "no" ; fi
[D] No Plugins found
[*] Launching the app...
[D] [REMOTE CMD] Remote Command: open com.apple.camera
[V] Retrieving the PID...
[D] [REMOTE CMD] Remote Command: ps ax | grep -i '/Applications/Camera.app/Camera'
[V] PID found: 2477
[*] Spawning a Cycript shell...
[D] [REMOTE CMD] Remote Interactive TTY Command: cycript -p 2477
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
cy#
```

To verify, I SShed into the iPhone to verify that the Camera app was at PID 2477:

```
root@YayComputerYay:~/Programs/needle/needle# ssh root@localhost -p 2222
root@localhost's password: 
Yay-iPhone-SE-Yay:~ root# ps ax | grep -i '/Applications/Camera.app/Camera'
 2477   ??  Ss     0:00.54 /Applications/Camera.app/Camera
 2496 s001  R+     0:00.00 grep -i /Applications/Camera.app/Camera
Yay-iPhone-SE-Yay:~ root# ps ax | grep -i 'Camera'                         
 2477   ??  Ss     0:00.55 /Applications/Camera.app/Camera
 2498 s001  R+     0:00.00 grep -i Camera
```

test results as follows:

ios 9
user app with a name that is one word: pass
system app with a name that is one word: pass
user app with a name that is more than one word: fail
system app with a name that is more than one word: fail

with my proposed fix, the 'PS' command now looks like this (used the system app Game Center as an example):

```
ps ax | grep -i ''/Applications/Game Center.app/Game Center''
```

i've come up with the following solutions for this, all of which looks ugly.

option 1) escape all spaces.

in the file "cycript_touchid.py", lines 21-23 would look like this:

```
binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
binaryPath = binaryPath.replace(" ","\ ")
pid = self.device.app.search_pid(binaryPath)
```

needle successfully finds the process "Game Center":

```
[D] [REMOTE CMD] Remote Command: ps ax | grep -i ''/Applications/Game\ Center.app/Game\ Center''
[V] PID found: 997
```

```
zaks-iPad:/Applications/Game Center.app root# ps ax | grep "Game Center"
  997   ??  Ss     0:18.37 /Applications/Game Center.app/Game Center
 1220 s001  R+     0:00.01 grep Game Center
```

needle successfully finds the application "Camera"

```
[D] [REMOTE CMD] Remote Command: ps ax | grep -i '/Applications/Camera.app/Camera'
[V] PID found: 715
```

```
zaks-iPad:/Applications/Game Center.app root# ps ax | grep "Camera"     
  715   ??  Us     0:01.83 /Applications/Camera.app/Camera
 1277 s001  R+     0:00.01 grep Camera
```

option 2) remove extra single quotes

in the file "cycript_touchid.py", lines 21-23 would look like this:

```
binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
binaryPath = binaryPath.replace("'","")
pid = self.device.app.search_pid(binaryPath)
```

needle successfully finds the application "Game Center"

```
[D] [REMOTE CMD] Remote Command: ps ax | grep -i '/Applications/Game Center.app/Game Center'
[V] PID found: 997
```

```
zaks-iPad:/Applications/Game Center.app root# ps ax | grep "Game Center"
  997   ??  Ss     0:27.42 /Applications/Game Center.app/Game Center
 1272 s001  R+     0:00.01 grep Game Center
```

needle successfully finds the application "Camera"

```
[D] [REMOTE CMD] Remote Command: ps ax | grep -i '/Applications/Camera.app/Camera'
[V] PID found: 715
```

```
zaks-iPad:/Applications/Game Center.app root# ps ax | grep "Camera"     
  715   ??  Us     0:01.83 /Applications/Camera.app/Camera
 1277 s001  R+     0:00.01 grep Camera
```

I've applied option 2 to this request.