### PR TITLE
Fix logic issue in "script_anti-hooking-check.py" if an app has not been set

### DIFF
--- a/needle/modules/hooking/frida/script_anti-hooking-check.py
+++ b/needle/modules/hooking/frida/script_anti-hooking-check.py
@@ -41,13 +41,13 @@ if(ObjC.available) {
     # ==================================================================================================================
     # RUN
     # ==================================================================================================================
-    def module_pre(self):
+    '''def module_pre(self):
         """Automatically detect if the app prevents hooking."""
         try:
             FridaScript.module_pre()
         except Exception as e:
             self.msg = e
-            self.module_run()
+            self.module_run()'''
 
     def module_run(self):
         # If error has been detected, log issue and exit


### PR DESCRIPTION
the "def module_pre(self)" function calls the function 'module_pre' in the class 'FridaScript' in the file '/needle/needle/core/framework/module.py'.

in this function, line 299 tries to spawn the app using 'self.app_metadata'. however, this assumes that the user had already set an app to begin with. usually, when you start a needle module and you haven't specified an app yet, needle will make the user go through the wizard of selecting an app.

so if the user had not specified an app yet before running this module, then needle will error out while trying to execute this module.

i opted to comment out the offending code in this module instead of deleting because i wasn't sure why the function 'module_pre' was in this module to begin with.

@marco-lancini has stated the following:

if an app hasn't been selected yet, then (rather than commenting out the entire module_pre function, you can do the following:

```
def module_pre(self):
        return FridaScript.module_pre(self, bypass_app=True)
```

the above fix results in the following error:

```
[needle] > set debug true
DEBUG => true
[needle] > use hooking/frida/script_anti-hooking-check
[needle][script_anti-hooking-check] > run
------------------------------------------------------------
Traceback (most recent call last):
  File "/root/Programs/needle/needle/core/framework/module.py", line 111, in do_run
    pre = self.module_pre()
  File "/root/Programs/needle/needle/modules/hooking/frida/script_anti-hooking-check.py", line 45, in module_pre
    return FridaScript.module_pre(self, bypass_app=True)
TypeError: module_pre() got an unexpected keyword argument 'bypass_app'
------------------------------------------------------------
[!] TypeError: module_pre() got an unexpected keyword argument 'bypass_app'
```

@HenryHoggard suggested patching 'framework/module.py' and adjusting 'module_pre' to call 'app_check()'.