### PR TITLE
Fix syntax issues in the module "script_hook-method-of-class"

### DIFF
--- a/needle/modules/hooking/frida/script_hook-method-of-class.py
+++ b/needle/modules/hooking/frida/script_hook-method-of-class.py
@@ -18,18 +18,20 @@ if(ObjC.available) {
     var className = "%s";
     var methodName = "%s";
 
-    var hook = eval('ObjC.classes.' + className + '["' + methodName + '"]');
+    var hook = eval('ObjC.classes[className][methodName]');
     Interceptor.attach(hook.implementation, {
           onEnter: function(args) {
                 // args[0] is self
                 // args[1] is selector (SEL "sendMessageWithText:")
                 // args[2] holds the first function argument, an NSString
-                console.log("[*] Detected call to: " + className + " -> " + funcName);
+                console.log("[*] Detected call to: " + className + " -> " + methodName);
                 //For viewing and manipulating arguments
                 //console.log("\t[-] Value1: "+ObjC.Object(args[2]));
                 //console.log("\t[-] Value2: "+(ObjC.Object(args[2])).toString());
                 //console.log(args[2]);
           }
+    });
+    Interceptor.attach(hook.implementation, {
           onLeave: function(retval) {
                 console.log("[*] Class Name: " + className);
                 console.log("[*] Method Name: " + methodName);


### PR DESCRIPTION
fixed three issues.

1) on line 21, fixed the same issue that was outlined in pull request https://github.com/mwrlabs/needle/pull/227. Credit to Kamil Wilk of MWR for coming up with this fix.

2) on line 27, 'funcName' was used instead of 'methodName'. Should have been 'methodName' to begin with.

3) lines 33-39 was supposed to return the result of the hooked method, but the frida script did not properly return the result. the proposed changes to lines 33 and 34 addresses this issue.