### PR TITLE
Add missing semicolon in script_touch-id-bypass.py

### DIFF
--- a/needle/modules/hooking/frida/script_touch-id-bypass.py
+++ b/needle/modules/hooking/frida/script_touch-id-bypass.py
@@ -16,7 +16,7 @@ if(ObjC.available) {
     var hook = ObjC.classes.LAContext["- evaluatePolicy:localizedReason:reply:"];
     Interceptor.attach(hook.implementation, {
         onEnter: function(args) {
-            send("Hooking Touch Id..")
+            send("Hooking Touch Id..");
             var block = new ObjC.Block(args[4]);
             const appCallback = block.implementation;
             block.implementation = function (error, value)  {


### PR DESCRIPTION
just a missing semicolon in the JavaScript portion of the module. technically this module works without the semicolon. but if a person were to take the JavaScript portion and use it as a one-liner in Frida, the user would have issues.