### PR TITLE
Fix "program" validate function in "theos_tweak.py"

### DIFF
--- a/needle/modules/hooking/theos/theos_tweak.py
+++ b/needle/modules/hooking/theos/theos_tweak.py
@@ -30,10 +30,10 @@ class Module(BaseModule):
     def __init__(self, params):
         BaseModule.__init__(self, params)
         self.options['substrate_filter'] = self.APP_METADATA['bundle_id'] if self.APP_METADATA else ""
-        # Ensure a valid editor has been specified
-        self.validate_editor()
 
     def __init_const(self):
+        # Ensure a valid editor has been specified
+        self.validate_editor()
         # Parse options
         project_name = self.options['project_name'].lower()
         package_name = 'needle.{}'.format(self.options['package_name'])


### PR DESCRIPTION
currently, the module "theos_tweak.py" does not validate if the option "program" is set to a proper value and always defaults to "vim". full needle output below:

```
[needle] > set debug true
DEBUG => true
[needle] > set app com.apple.camera
APP => com.apple.camera
[needle] > use hooking/theos/theos_tweak
[needle][theos_tweak] > set program YAYPROGRAMYAY
PROGRAM => YAYPROGRAMYAY
[needle][theos_tweak] > set package_name yaypackageyay
PACKAGE_NAME => yaypackageyay
[needle][theos_tweak] > set project_name yayprojectyay
PROJECT_NAME => yayprojectyay
[needle][theos_tweak] > show options

  Name              Current Value  Required  Description
  ----------------  -------------  --------  -----------
  PACKAGE_NAME      yaypackageyay  yes       Package Name [yourcompany.test]. The "needle." prefix will be automatically added
  PROGRAM           YAYPROGRAMYAY  yes       Select the program to use for editing files. Currently supported: VIM, NANO
  PROJECT_NAME      yayprojectyay  yes       Project name
  SUBSTRATE_FILTER                 no        MobileSubstrate Bundle filter [com.apple.springboard]
  TERMINATE_APP                    no        List of applications to terminate upon installation (space-separated) [SpringBoard]

[needle][theos_tweak] > run
[D] Setup local output folder: /root/.needle/output
[D] Setting up issues database...
[D] [DB] QUERY: CREATE TABLE IF NOT EXISTS issues (app TEXT, module TEXT, name TEXT, content TEXT, confidence TEXT, outfile TEXT)
[*] Checking connection with device...
[V] Connection not present, creating a new instance
[D] Setting up USB port forwarding on port 2222
[D] [LOCAL CMD] Local Subprocess Command: /root/Programs/needle/needle/libs/usbmuxd/tcprelay.py -t 22:2222
[D] [AGENT] Setting up port forwarding on port 4444
[V] [AGENT] Connecting to agent (127.0.0.1:4444)...
[+] [AGENT] Successfully connected to agent (127.0.0.1:4444)...
[D] [AGENT] Executing command: os_version
[V] [SSH] Connecting (127.0.0.1:2222)...
[+] [SSH] Connected (127.0.0.1:2222)
[D] Creating temp folder: /var/root/needle/
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/ ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: mkdir /var/root/needle/
[D] [AGENT] Executing command: os_version
[+] Target app: com.apple.camera
[*] Retrieving app's metadata...
[D] [AGENT] Executing command: list_apps
[D] Copying the plist to temp: /Applications/Camera.app/Info.plist -> /root/.needle/tmp/plist
[*] Pulling: /Applications/Camera.app/Info.plist -> /root/.needle/tmp/plist
[D] Downloading: "/Applications/Camera.app/Info.plist" -> /root/.needle/tmp/plist
[D] [LOCAL CMD] Local Command: sshpass -p "<password>" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 2222 root@127.0.0.1:"/Applications/Camera.app/Info.plist" /root/.needle/tmp/plist
[D] [REMOTE CMD] Remote Command: lipo -info /Applications/Camera.app/Camera
[D] [REMOTE CMD] Remote Command: if [ -d /Applications/Camera.app/PlugIns ]; then echo "yes"; else echo "no" ; fi
[D] No Plugins found
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/yayprojectyay ]; then echo "yes"; else echo "no" ; fi
[*] Starting wizard...
[D] [REMOTE CMD] Remote Command: cd /var/root/needle/ && printf '11\nyayprojectyay\nneedle.yaypackageyay\nNeedle\n\n-' | perl /private/var/theos/bin/nic.pl
[*] Tweak created:
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/yayprojectyay ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: ls  /var/root/needle/yayprojectyay
	Makefile
	Tweak.xm
	control
	yayprojectyay.plist
[*] Pulling: /var/root/needle/yayprojectyay/Tweak.xm -> /root/.needle/output/Tweak.xm
[D] Downloading: "/var/root/needle/yayprojectyay/Tweak.xm" -> /root/.needle/output/Tweak.xm
[D] [LOCAL CMD] Local Command: sshpass -p "<password>" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 2222 root@127.0.0.1:"/var/root/needle/yayprojectyay/Tweak.xm" /root/.needle/output/Tweak.xm
[D] [LOCAL CMD] Local Interactive Command: vim /root/.needle/output/Tweak.xm
[*] Uploading new Tweak to device...
[*] Pushing: /root/.needle/output/Tweak.xm -> /var/root/needle/yayprojectyay/Tweak.xm
[D] Uploading: "/root/.needle/output/Tweak.xm" -> "/var/root/needle/yayprojectyay/Tweak.xm"
[D] [LOCAL CMD] Local Command: sshpass -p "<password>" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 2222 -r "/root/.needle/output/Tweak.xm" root@127.0.0.1:"/var/root/needle/yayprojectyay/Tweak.xm"
[*] Installing the Tweak...
[D] [REMOTE CMD] Remote Interactive TTY Command: export THEOS=/private/var/theos && export PATH=$THEOS/bin:$PATH && cd /var/root/needle/yayprojectyay && make package install
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
```

moving "self.validate_editor()" further down the script fixes this issue.