### PR TITLE
Fix how the module "heap_dump.py" finds processes via "ps ax | grep"

### DIFF
--- a/needle/modules/dynamic/memory/heap_dump.py
+++ b/needle/modules/dynamic/memory/heap_dump.py
@@ -31,7 +31,9 @@ class Module(BaseModule):
         # Launch the app
         self.printer.info("Launching the app...")
         self.device.app.open(self.APP_METADATA['bundle_id'])
-        pid = self.device.app.search_pid(self.APP_METADATA['binary_name'])
+        binaryPath = self.APP_METADATA['binary_path'].replace("/private","")
+        binaryPath = binaryPath.replace("'","")
+        pid = self.device.app.search_pid(binaryPath)
 
         # Create temp files/folders
         dir_dumps = self.device.remote_op.build_temp_path_for_file("gdb_dumps")


### PR DESCRIPTION
as discussed with previous pull requests, this module may not find the correct process to attach to.

before the proposed code fix, the following is the full needle output showing gdb attaching to the process "/usr/libexec/pipelined" instead of the application "jp.naver.line":

```
[needle][heap_dump] > run
[*] Checking connection with device...
[+] Already connected to: 127.0.0.1
[D] Creating temp folder: /var/root/needle/
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/ ]; then echo "yes"; else echo "no" ; fi
[+] Target app: jp.naver.line
[*] Launching the app...
[D] [REMOTE CMD] Remote Command: open jp.naver.line
[V] Retrieving the PID...
[D] [REMOTE CMD] Remote Command: ps ax | grep -i 'LINE'
[V] PID found: 2404
[D] [REMOTE CMD] Remote Command: echo "info mach-regions" > /var/root/needle/gdb_mach
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: rm -rf /var/root/needle/gdb_dumps 2> /dev/null
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: mkdir /var/root/needle/gdb_dumps
[*] Enumerating mach regions...
[D] [REMOTE CMD] Remote Command:         gdb --pid="2404" --batch --command=/var/root/needle/gdb_mach 2>/dev/null | grep sub-regions | awk '{print $3,$5}' | while read range; do
        echo "mach-regions: $range"
        cmd="dump binary memory /var/root/needle/gdb_dumps/dump`echo $range| awk '{print $1}'`.dmp $range"
        echo "$cmd" >> /var/root/needle/gdb_ranges
        done 
[*] Dumping memory (it might take a while)...
[D] [REMOTE CMD] Remote Command: gdb --pid="2404" --batch --command=/var/root/needle/gdb_ranges &>>/dev/null
[V] Checking if we have dumps...
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: ls -aR /var/root/needle/gdb_dumps
[*] Extracting strings...
[D] [REMOTE CMD] Remote Command: strings /var/root/needle/gdb_dumps/* 2>/dev/null | grep -i "LINE"
[?] No strings found. The app might employ anti-debugging techniques.
[needle][heap_dump] > shell
[*] Spawning a shell...
[*] Checking connection with device...
[+] Already connected to: 127.0.0.1
[D] [LOCAL CMD] Local Interactive Command: sshpass -p "alpine" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2222 root@127.0.0.1
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Yay-iPhone-SE-Yay:~ root# ps ax | grep -i 'LINE'
 2404   ??  Ss     0:03.93 /usr/libexec/pipelined
 2660   ??  Ss     0:00.44 /usr/libexec/online-auth-agent
 4736   ??  Ss     0:00.93 /var/containers/Bundle/Application/D60E68D2-BCFA-48C7-AC5C-348F7315D4BB/LINE.app/LINE
 4969 s001  R+     0:00.00 grep -i LINE
```

full needle output after applying the proposed code fix:

```
[needle][heap_dump] > run
[*] Checking connection with device...
[+] Already connected to: 127.0.0.1
[D] Creating temp folder: /var/root/needle/
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/ ]; then echo "yes"; else echo "no" ; fi
[+] Target app: jp.naver.line
[*] Launching the app...
[D] [REMOTE CMD] Remote Command: open jp.naver.line
[V] Retrieving the PID...
[D] [REMOTE CMD] Remote Command: ps ax | grep -i '/var/containers/Bundle/Application/D60E68D2-BCFA-48C7-AC5C-348F7315D4BB/LINE.app/LINE'
[V] PID found: 4736
[D] [REMOTE CMD] Remote Command: echo "info mach-regions" > /var/root/needle/gdb_mach
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: rm -rf /var/root/needle/gdb_dumps 2> /dev/null
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: mkdir /var/root/needle/gdb_dumps
[*] Enumerating mach regions...
[D] [REMOTE CMD] Remote Command:         gdb --pid="4736" --batch --command=/var/root/needle/gdb_mach 2>/dev/null | grep sub-regions | awk '{print $3,$5}' | while read range; do
        echo "mach-regions: $range"
        cmd="dump binary memory /var/root/needle/gdb_dumps/dump`echo $range| awk '{print $1}'`.dmp $range"
        echo "$cmd" >> /var/root/needle/gdb_ranges
        done 
[*] Dumping memory (it might take a while)...
[D] [REMOTE CMD] Remote Command: gdb --pid="4736" --batch --command=/var/root/needle/gdb_ranges &>>/dev/null
[V] Checking if we have dumps...
[D] [REMOTE CMD] Remote Command: if [ -d /var/root/needle/gdb_dumps ]; then echo "yes"; else echo "no" ; fi
[D] [REMOTE CMD] Remote Command: ls -aR /var/root/needle/gdb_dumps
[*] Extracting strings...
[D] [REMOTE CMD] Remote Command: strings /var/root/needle/gdb_dumps/* 2>/dev/null | grep -i "LINE"
[?] No strings found. The app might employ anti-debugging techniques.
[needle][heap_dump] > shell
[*] Spawning a shell...
[*] Checking connection with device...
[+] Already connected to: 127.0.0.1
[D] [LOCAL CMD] Local Interactive Command: sshpass -p "alpine" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2222 root@127.0.0.1
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Yay-iPhone-SE-Yay:~ root# ps ax | grep -i 'LINE'
 2404   ??  Ss     0:03.93 /usr/libexec/pipelined
 2660   ??  Ss     0:00.44 /usr/libexec/online-auth-agent
 4736   ??  Ss     0:01.02 /var/containers/Bundle/Application/D60E68D2-BCFA-48C7-AC5C-348F7315D4BB/LINE.app/LINE
 5463 s000  R+     0:00.00 grep -i LINE
```