### PR TITLE
Fix execution permissions while installing the dependency "Clutch"

### DIFF
--- a/needle/core/utils/constants.py
+++ b/needle/core/utils/constants.py
@@ -157,6 +157,7 @@ class Constants(object):
             'CLUTCH': {'COMMAND': 'Clutch2', 'PACKAGES': None, 'REPO': None, 'LOCAL': None, 'SETUP': [
                 "curl -ksL \"http://cydia.iphonecake.com/Clutch2.0.4.deb\" -o /var/root/clutch.deb",
                 "dpkg -i /var/root/clutch.deb && rm -f /var/root/clutch.deb",
+                "chmod +x /usr/bin/Clutch2",
                 "killall -HUP SpringBoard"
             ]},
             'CURL': {'COMMAND': 'curl', 'PACKAGES': ['curl'], 'REPO': None, 'LOCAL': None, 'SETUP': None},


### PR DESCRIPTION
When using the module 'device/dependency_installer', Needle does the following:

```
[V] [INSTALL] Manually installing: CLUTCH
[D] [REMOTE CMD] Remote Command: curl -ksL "http://cydia.iphonecake.com/Clutch2.0.4.deb" -o /var/root/clutch.deb
[D] [REMOTE CMD] Remote Command: dpkg -i /var/root/clutch.deb && rm -f /var/root/clutch.deb
[D] [REMOTE CMD] Remote Command: killall -HUP SpringBoard
```

After installing the Clutch binary, you are not able to run it due to the execution permissions being not applied to the binary:

```
Yay-iPhone-SE-Yay:/usr/bin root# Clutch
-sh: /usr/bin/Clutch: Permission denied
Yay-iPhone-SE-Yay:/usr/bin root# ls -la | grep -i clutch
lrwxr-xr-x  1 root   wheel       16 Feb 27 10:16 Clutch -> /usr/bin/Clutch2
-rw-r--r--  1 root   wheel  1232832 Aug 23  2016 Clutch2
```

The proposed change will fix this issue:

```
[V] [INSTALL] Manually installing: CLUTCH
[D] [REMOTE CMD] Remote Command: curl -ksL "http://cydia.iphonecake.com/Clutch2.0.4.deb" -o /var/root/clutch.deb
[D] [REMOTE CMD] Remote Command: dpkg -i /var/root/clutch.deb && rm -f /var/root/clutch.deb
[D] [REMOTE CMD] Remote Command: chmod +x /usr/bin/Clutch2
[D] [REMOTE CMD] Remote Command: killall -HUP SpringBoard
[needle][dependency_installer] > shell
[*] Spawning a shell...
[*] Checking connection with device...
[+] Already connected to: 127.0.0.1
[D] [LOCAL CMD] Local Interactive Command: sshpass -p "alpine" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2222 root@127.0.0.1
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Yay-iPhone-SE-Yay:~ root# cd /usr/bin
Yay-iPhone-SE-Yay:/usr/bin root# Clutch
Usage: Clutch [OPTIONS]
-b --binary-dump <value> Only dump binary files from specified bundleID 
-d --dump <value>        Dump specified bundleID into .ipa file 
-i --print-installed     Print installed applications 
   --clean               Clean /var/tmp/clutch directory 
   --version             Display version and exit 
-? --help                Display this help and exit 
-n --no-color            Print with colors disabled 
```