### PR TITLE
Fix the installation process for installing Theos while using the module 'device/dependency_installer' 

### DIFF
--- a/needle/core/utils/constants.py
+++ b/needle/core/utils/constants.py
@@ -144,11 +144,13 @@ class Constants(object):
             'FRIDA32BIT': {'COMMAND': 'frida', 'PACKAGES': ['re.frida.server32'], 'REPO': 'https://build.frida.re/', 'LOCAL': None, 'SETUP': None},
             'GDB': {'COMMAND': 'gdb', 'PACKAGES': ['gdb'], 'REPO': 'http://cydia.radare.org/', 'LOCAL': None, 'SETUP': None},
             'THEOS': {'COMMAND': 'theos', 'PACKAGES': None, 'REPO': None, 'LOCAL': None, 'SETUP': [
-                "ln -s /usr/local/bin/perl /usr/bin/perl",
-                "GIT_SSL_NO_VERIFY=true git clone --recursive https://github.com/theos/theos.git %s" % THEOS_FOLDER,
-                "mkdir -p %ssdks" % THEOS_FOLDER,
-                "curl -ksL \"https://sdks.website/dl/iPhoneOS8.1.sdk.tbz2\" | tar -xj -C %ssdks" % THEOS_FOLDER,
-                "curl -ksL \"https://sdks.website/dl/iPhoneOS9.3.sdk.tbz2\" | tar -xj -C %ssdks" % THEOS_FOLDER,
+                "ln -sf /usr/local/bin/perl /usr/bin/perl",
+                "rm -rf %s" % THEOS_FOLDER,
+                "GIT_SSL_NO_VERIFY=true git clone --quiet git://github.com/theos/theos.git %s" % THEOS_FOLDER,
+                "cd %s && git submodule init --quiet" % THEOS_FOLDER,
+                "sed -i -- 's/https/git/g' %s.git/config" % THEOS_FOLDER,
+                "cd %s && git submodule update --quiet" % THEOS_FOLDER,
+                "rm -rf %ssdks && git clone --quiet git://github.com/theos/sdks.git %ssdks" %(THEOS_FOLDER, THEOS_FOLDER)
             ]},
             'THEOS_NIC': {'COMMAND': '%sbin/nic.pl' % THEOS_FOLDER, 'PACKAGES': None, 'REPO': None, 'LOCAL': None, 'SETUP': None},
 


### PR DESCRIPTION
Multiple issues addressed. 

Issue 1: Symbolic linking fails if file exists

Current line 147:
```
"ln -s /usr/local/bin/perl /usr/bin/perl"
```

If the user were to already have "/usr/bin/perl" then the following error would occur in Needle:
```
[V] [INSTALL] Manually installing: THEOS
[D] [REMOTE CMD] Remote Command: ln -s /usr/local/bin/perl /usr/bin/perl
[!] ln: failed to create symbolic link `/usr/bin/perl': File exists

[V] [SSH] Disconnecting...
[V] [AGENT] Disconnecting from agent...
```

By adding the flag "-f" to the command, the symbolic link will be forced.

New proposed command:
```
"ln -sf /usr/local/bin/perl /usr/bin/perl"
```
===================================

Issue 2: Git clone fails if folder exists

Current line 148:
```
"GIT_SSL_NO_VERIFY=true git clone --recursive https://github.com/theos/theos.git %s" % THEOS_FOLDER
```
THEOS_FOLDER is set to '/private/var/theos'.

If the folder '/private/var/theos' already exists then the user will be presented with the following Needle error:

```
V] [INSTALL] Manually installing: THEOS
[D] [REMOTE CMD] Remote Command: ln -sf /usr/local/bin/perl /usr/bin/perl
[D] [REMOTE CMD] Remote Command: GIT_SSL_NO_VERIFY=true git clone --recursive https://github.com/theos/theos.git /private/var/theos/
[!] fatal: destination path '/private/var/theos' already exists and is not an empty directory.

[V] [SSH] Disconnecting...
[V] [AGENT] Disconnecting from agent...
```

Solution is to remove '/private/var/theos' before using the 'git clone' command.

Proposed line 148 before running the git clone command:
```
"rm -rf %s" % THEOS_FOLDER
```

===================================

Issue 3: Git command errors

The following errors were found while running the following Git versions when trying to clone the Theos project:

Git version 2.13.0 downloaded from repo 'cydia.radare.org'
```
Yay-iPhone-SE-Yay:~ root# git --version
git version 2.13.0
Yay-iPhone-SE-Yay:~ root# GIT_SSL_NO_VERIFY=true git clone --recursive https://github.com/theos/theos.git /private/var/theos/
Cloning into '/private/var/theos'...
fatal: Unable to find remote helper for 'https'
```

Git version 2.8.1 download from repo 'apt.saurik.com'
```
Yay-iPhone-SE-Yay:~ root# git --version
git version 2.8.1
Yay-iPhone-SE-Yay:~ root# GIT_SSL_NO_VERIFY=true git clone --recursive https://github.com/theos/theos.git /private/var/theos/
Cloning into '/private/var/theos'...
fatal: unable to access 'https://github.com/theos/theos.git/': error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version
```

Proposed change to the project URL would be "git://github.com/theos/theos.git" instead of "https://github.com/theos/theos.git". 

However, because of the "--recursive" flag in the "git clone" command, this means that submodules need to be downloaded as well. The Theos project has it's ".git/config" file set to point to "https://github.com" instead of "git://github.com":
```
Yay-iPhone-SE-Yay:/private/var/theos root# cat .git/config
[core]
	repositoryformatversion = 0
	filemode = true
	bare = false
	logallrefupdates = true
	precomposeunicode = true
[remote "origin"]
	url = git://github.com/theos/theos.git
	fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
	remote = origin
	merge = refs/heads/master
[submodule "vendor/dm.pl"]
	url = https://github.com/theos/dm.pl.git
[submodule "vendor/include"]
	url = https://github.com/theos/headers.git
[submodule "vendor/lib"]
	url = https://github.com/theos/lib.git
[submodule "vendor/logos"]
	url = https://github.com/theos/logos.git
[submodule "vendor/nic"]
	url = https://github.com/theos/nic.git
```

To remedy this, instead of specifying the "--recursive" flag with the "git clone" command, we can manually run "git module init" and then modify each URL in the "config" file so that "https://" is changed to "git://". Finally, we use "git submodule update" to download each submodule.

Proposed lines 149-152

```
"GIT_SSL_NO_VERIFY=true git clone --quiet git://github.com/theos/theos.git %s" % THEOS_FOLDER, #clone Theos into /private/var/theos quietly
"cd %s && git submodule init --quiet" % THEOS_FOLDER, #change directory to /private/var/theos and initiate the git submodules
"sed -i -- 's/https/git/g' %s.git/config" % THEOS_FOLDER, #take the .git/config file and replace all instances of "https" with "git"
"cd %s && git submodule update --quiet" % THEOS_FOLDER, #use git to download the submodules to the appropriate folders
```

The above lines work with both Git versions 2.13.0 and 2.8.1

===================================

Issue 4: outdated SDK URLs

The current commands to download the SDK files look like the following:

```
"curl -ksL \"https://sdks.website/dl/iPhoneOS8.1.sdk.tbz2\" | tar -xj -C %ssdks" % THEOS_FOLDER,
"curl -ksL \"https://sdks.website/dl/iPhoneOS9.3.sdk.tbz2\" | tar -xj -C %ssdks" % THEOS_FOLDER,
```

The URL "https://sdks.website" currently does not host any SDK files. The same developer of Theos currently has SDK files for 9.3 and 10.1 at the repository https://github.com/theos/sdks.

The following proposed line 153 will clone the https://github.com/theos/sdks repository into /private/var/theos/sdks:
```
"rm -rf %ssdks && git clone --quiet git://github.com/theos/sdks.git %ssdks" %(THEOS_FOLDER, THEOS_FOLDER)
```