### PR TITLE
Fix logic issue in "code_checks.py"

### DIFF
--- a/needle/modules/static/code_checks.py
+++ b/needle/modules/static/code_checks.py
@@ -168,7 +168,7 @@ class Module(StaticModule):
                 for r in results:
                     file_output.append('\t[{:<80}] line {:<5} -> {:<30}'.format(r['name'], r['linenum'], r['line']))
                     print('\t{}[{:<80}]{} line {:<5}{} -> {:<30}'.format(Colors.B, r['name'], Colors.O, r['linenum'], Colors.N, r['line']))
-                self.add_issue('Static code analysis: {}'.format(category), '{} results'.format(len(results)), 'INVESTIGATE', outfile)
+                #self.add_issue('Static code analysis: {}'.format(category), '{} results'.format(len(results)), 'INVESTIGATE', outfile)
 
         # Save to file
         self.print_cmd_output(file_output, outfile, silent=True)


### PR DESCRIPTION
Currently, line 171 of "code_checks.py" instructs Needle to carry out "add_issue" within "/needle/core/framework/module.py". This function requires the following info:

```
self.APP_METADATA['bundle_id']
self.meta['path']
```

The issue is that "self.APP_METADATA['bundle_id']" requires the user to have obtained the metadata of an application on their iPhone. One way to obtain this information is to run the module "binary/info/metadata".

The proposed fix tells Needle to not run "add_issue" within "module.py". This allows the static code check to complete without having to rely on "self.APP_METADATA['bundle_id']" not being NULL.