### PR TITLE
Fix Handling of periods in class names - script_hook-all-methods-of-class.py

### DIFF
--- a/needle/modules/hooking/frida/script_hook-all-methods-of-class.py
+++ b/needle/modules/hooking/frida/script_hook-all-methods-of-class.py
@@ -15,12 +15,12 @@ class Module(FridaScript):
     JS = '''\
 if(ObjC.available) {
     var className = "%s";
-    var methods = eval('ObjC.classes.' + className + '.$methods');
+    var methods = eval('ObjC.classes[className].$ownMethods');
     console.log("[*] Hooking methods");
     for (var i = 0; i < methods.length; i++)
     {
         var funcName = methods[i];
-        var hook = eval('ObjC.classes.' + className + '["'+funcName+'"]');
+        var hook = eval('ObjC.classes[className][funcName]');
         Interceptor.attach(hook.implementation, {
             onEnter: function(args) {
                 console.log("[*] Detected call to: " + className.toString() + " -> " + funcName.toString());


### PR DESCRIPTION
Addresses the same issue outlined in PR https://github.com/mwrlabs/needle/pull/227